### PR TITLE
fix: 홈 화면 레이아웃 수정 (스크롤 제거, CTA 고정)

### DIFF
--- a/src/components/home/FixedCTA.tsx
+++ b/src/components/home/FixedCTA.tsx
@@ -26,7 +26,7 @@ function FixedCTA({ selectedPresetId, selectedScenario }: FixedCTAProps) {
   }
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 p-4 pb-[calc(1rem+env(safe-area-inset-bottom))]">
+    <div className="flex-shrink-0 bg-white border-t border-gray-200 p-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
       <button
         type="button"
         onClick={handleClick}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -36,9 +36,9 @@ function HomePage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 pb-24">
+    <div className="h-screen flex flex-col bg-gray-50 overflow-hidden">
       {/* 헤더 */}
-      <header className="bg-white border-b border-gray-200 px-4 py-4 flex justify-between items-center">
+      <header className="flex-shrink-0 bg-white border-b border-gray-200 px-4 py-4 flex justify-between items-center">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">속지마랑</h1>
           <p className="text-sm text-gray-500">보이스피싱 예방 훈련</p>
@@ -52,7 +52,8 @@ function HomePage() {
         </button>
       </header>
 
-      <main>
+      {/* 메인 콘텐츠 */}
+      <main className="flex-1 overflow-hidden">
         <PresetCarousel
           selectedPresetId={selectedPresetId}
           onSelectPreset={handlePresetSelect}
@@ -64,6 +65,7 @@ function HomePage() {
         />
       </main>
 
+      {/* 하단 CTA */}
       <FixedCTA
         selectedPresetId={selectedPresetId}
         selectedScenario={selectedScenario}


### PR DESCRIPTION
## Summary
- 홈 화면에서 불필요한 스크롤 제거
- 하단 CTA 버튼이 화면 밖으로 벗어나는 문제 수정
- 모든 콘텐츠가 한 화면에 보이도록 레이아웃 개선

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `src/routes/index.tsx` | `min-h-screen pb-24` → `h-screen flex flex-col overflow-hidden` |
| `src/components/home/FixedCTA.tsx` | `fixed bottom-0` → `flex-shrink-0` |

## Technical Details
- **Flexbox 레이아웃**: `h-screen flex flex-col`로 전체 화면을 채우는 구조
- **overflow-hidden**: 불필요한 스크롤 제거
- **flex-shrink-0**: 헤더와 CTA가 고정 크기 유지
- **flex-1**: 메인 콘텐츠가 남은 공간을 채움

## Test Plan
- [ ] 홈 화면에서 스크롤이 발생하지 않음
- [ ] CTA 버튼이 화면 하단에 고정되어 보임
- [ ] 프리셋/시나리오 카루셀이 정상 표시됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)